### PR TITLE
Add 09_all_esysroot.patch for having ESYSROOT effectively set --sysroot

### DIFF
--- a/14.1.0/gentoo/09_all_esysroot.patch
+++ b/14.1.0/gentoo/09_all_esysroot.patch
@@ -1,0 +1,67 @@
+From a2e98f3928a4bef1f9a027f8af22b019beff9600 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Sun, 4 Aug 2024 17:02:06 +0100
+Subject: [PATCH] Allow setting target sysroot with ESYSROOT env var for
+ cross-compilers
+
+The variable is ignored for native compilers. The --sysroot command line
+option takes precedence.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/doc/invoke.texi | 10 ++++++++++
+ gcc/gcc.cc          | 10 ++++++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index f82f7d281..2f03b080d 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -19027,6 +19027,10 @@ for this option.  If your linker does not support this option, the
+ header file aspect of @option{--sysroot} still works, but the
+ library aspect does not.
+ 
++On Gentoo Linux, this option can also be set for cross-compilers using the
++@env{ESYSROOT} environmnent variable.  The variable is ignored for native
++compilers.  The command line option takes precedence.
++
+ @opindex no-sysroot-suffix
+ @item --no-sysroot-suffix
+ For some targets, a suffix is added to the root directory specified
+@@ -37409,6 +37413,12 @@ using GCC also uses these directories when searching for ordinary
+ libraries for the @option{-l} option (but directories specified with
+ @option{-L} come first).
+ 
++@vindex ESYSROOT
++@item ESYSROOT
++On Gentoo Linux, this variable sets the logical root directory for headers and
++libraries for cross-compilers.  It is ignored for native compilers.  The
++@option{--sysroot} option takes precedence.
++
+ @vindex LANG
+ @cindex locale definition
+ @item LANG
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 728332b81..06d8c469b 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5501,6 +5501,16 @@ process_command (unsigned int decoded_options_count,
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 1);
+   free (tooldir_prefix);
+ 
++  if (*cross_compile == '1' && !target_system_root_changed)
++    {
++      const char *esysroot = env.get("ESYSROOT");
++      if (esysroot && esysroot[0] != '\0' && strcmp(esysroot, "/") != 0 && (!target_system_root || strcmp(esysroot, target_system_root) != 0))
++	{
++	  target_system_root = esysroot;
++	  target_system_root_changed = 1;
++	}
++    }
++
+ #if defined(TARGET_SYSTEM_ROOT_RELOCATABLE) && !defined(VMS)
+   /* If the normal TARGET_SYSTEM_ROOT is inside of $exec_prefix,
+      then consider it to relocate with the rest of the GCC installation
+-- 
+2.45.2
+

--- a/14.1.0/gentoo/README.history
+++ b/14.1.0/gentoo/README.history
@@ -1,3 +1,7 @@
+5   ????
+
+	+ 09_all_esysroot.patch
+
 4	21 July 2024
 
 	- 76_all_ppc_PR97367-power7-cell-altivec.patch

--- a/15.0.0/gentoo/09_all_esysroot.patch
+++ b/15.0.0/gentoo/09_all_esysroot.patch
@@ -1,0 +1,67 @@
+From 71e048084d32811f6e17e73b6ebadfe550ef1193 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Sun, 4 Aug 2024 17:02:06 +0100
+Subject: [PATCH] Allow setting target sysroot with ESYSROOT env var for
+ cross-compilers
+
+The variable is ignored for native compilers. The --sysroot command line
+option takes precedence.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/doc/invoke.texi | 10 ++++++++++
+ gcc/gcc.cc          | 10 ++++++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index 0fe99ca8e..434cf30e2 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -19230,6 +19230,10 @@ for this option.  If your linker does not support this option, the
+ header file aspect of @option{--sysroot} still works, but the
+ library aspect does not.
+ 
++On Gentoo Linux, this option can also be set for cross-compilers using the
++@env{ESYSROOT} environmnent variable.  The variable is ignored for native
++compilers.  The command line option takes precedence.
++
+ @opindex no-sysroot-suffix
+ @item --no-sysroot-suffix
+ For some targets, a suffix is added to the root directory specified
+@@ -37657,6 +37661,12 @@ using GCC also uses these directories when searching for ordinary
+ libraries for the @option{-l} option (but directories specified with
+ @option{-L} come first).
+ 
++@vindex ESYSROOT
++@item ESYSROOT
++On Gentoo Linux, this variable sets the logical root directory for headers and
++libraries for cross-compilers.  It is ignored for native compilers.  The
++@option{--sysroot} option takes precedence.
++
+ @vindex LANG
+ @cindex locale definition
+ @item LANG
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index abdb40bfe..956363ddb 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5516,6 +5516,16 @@ process_command (unsigned int decoded_options_count,
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 1);
+   free (tooldir_prefix);
+ 
++  if (*cross_compile == '1' && !target_system_root_changed)
++    {
++      const char *esysroot = env.get("ESYSROOT");
++      if (esysroot && esysroot[0] != '\0' && strcmp(esysroot, "/") != 0 && (!target_system_root || strcmp(esysroot, target_system_root) != 0))
++	{
++	  target_system_root = esysroot;
++	  target_system_root_changed = 1;
++	}
++    }
++
+ #if defined(TARGET_SYSTEM_ROOT_RELOCATABLE) && !defined(VMS)
+   /* If the normal TARGET_SYSTEM_ROOT is inside of $exec_prefix,
+      then consider it to relocate with the rest of the GCC installation
+-- 
+2.45.2
+

--- a/15.0.0/gentoo/README.history
+++ b/15.0.0/gentoo/README.history
@@ -1,6 +1,7 @@
 ?	????
 
 	- 78_all_gcc_don-t-enable-fext-dce-with-O2-for-now.patch
+	+ 09_all_esysroot.patch
 
 8	5 August 2024
 


### PR DESCRIPTION
Tested against 13.2.1 and 14.2.0, but I don't need it backported to the former. Applies cleanly to 15.0.0 but admittedly untested there.

My tests include a two-phase build of the entire Flatcar Linux distro, cross-compiled for amd64 and arm64.

I do have an alternative plan for Clang that doesn't involve patching.