### PR TITLE
Add two small tooldir prefix patches to aid cross-compiling

### DIFF
--- a/14.2.0/gentoo/12_all_tooldir_prefix_lib.patch
+++ b/14.2.0/gentoo/12_all_tooldir_prefix_lib.patch
@@ -1,0 +1,44 @@
+From 018edcc1c4649cccc86d9cb248efbc5ec9357293 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Thu, 2 Jan 2025 12:54:41 +0000
+Subject: [PATCH 1/3] Do not search for libs relative to the driver when
+ sysroot is changed
+
+When specifying a sysroot, the intention is to link against libraries in
+that sysroot rather than the toolchain's default sysroot. Having the
+toolchain default take priority is problematic, as libraries there may
+not be ABI compatible or may even have different sonames altogether.
+The desired sysroot is also not applied to ld scripts.
+
+Gentoo previously got away with this because only the toolchain's /lib
+was searched rather than /usr/lib, and the former did not contain many
+*.so files. Now that Gentoo is migrating cross environments to a
+merged-usr layout, these directories are the same, triggering the above
+issues much more frequently.
+
+In particular, the toolchain's /usr/lib/libc.so ld script is found
+before the sysroot's. This includes a reference to /lib/libc.so.6. The
+sysroot is only applied to this when the ld script itself is within that
+sysroot, so /lib/libc.so.6 is taken literally, causing the build
+machine's libc to be used instead, which immediately breaks any linking.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/gcc.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 728332b81..bef473939 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5496,6 +5496,7 @@ process_command (unsigned int decoded_options_count,
+   add_prefix (&exec_prefixes,
+ 	      concat (tooldir_prefix, "bin", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 0);
++  if (!target_system_root_changed)
+   add_prefix (&startfile_prefixes,
+ 	      concat (tooldir_prefix, "lib", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 1);
+-- 
+2.47.1
+

--- a/14.2.0/gentoo/13_all_tooldir_prefix_bin.patch
+++ b/14.2.0/gentoo/13_all_tooldir_prefix_bin.patch
@@ -1,0 +1,35 @@
+From 886520dcf2a59105cc78573f4c5a5cb34ad05579 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Thu, 2 Jan 2025 12:46:55 +0000
+Subject: [PATCH 2/3] Do not search for tools relative to the driver when
+ cross-compiling
+
+On Gentoo, this location is /usr/${CHOST}/bin. Native toolchains put
+symlinks to the binutils tools here. Cross toolchains only put
+non-native binaries here. The binutils symlinks live under
+/usr/libexec/gcc/${CHOST} instead, and that location is already
+searched.
+
+It would be better to fail to find a given tool than inadvertently try
+to execute a non-native build of it via QEMU.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/gcc.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index bef473939..20044bc3a 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5493,6 +5493,7 @@ process_command (unsigned int decoded_options_count,
+ 	      accel_dir_suffix, dir_separator_str, tooldir_prefix2, NULL);
+   free (tooldir_prefix2);
+ 
++  if (*cross_compile == '0')
+   add_prefix (&exec_prefixes,
+ 	      concat (tooldir_prefix, "bin", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 0);
+-- 
+2.47.1
+

--- a/14.2.0/gentoo/README.history
+++ b/14.2.0/gentoo/README.history
@@ -1,3 +1,8 @@
+8	????
+
+	+ 12_all_tooldir_prefix_lib.patch
+	+ 13_all_tooldir_prefix_bin.patch
+
 7	24 Dec 2024
 
 	U 70_all_PR117854-config-nvptx-fix-bashisms-with-gen-copyright.sh-use.patch

--- a/15.0.0/gentoo/12_all_tooldir_prefix_lib.patch
+++ b/15.0.0/gentoo/12_all_tooldir_prefix_lib.patch
@@ -1,0 +1,44 @@
+From dc817f621aa5a99ce05d9336aa8ef57835fc009b Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Thu, 2 Jan 2025 12:54:41 +0000
+Subject: [PATCH 1/3] Do not search for libs relative to the driver when
+ sysroot is changed
+
+When specifying a sysroot, the intention is to link against libraries in
+that sysroot rather than the toolchain's default sysroot. Having the
+toolchain default take priority is problematic, as libraries there may
+not be ABI compatible or may even have different sonames altogether.
+The desired sysroot is also not applied to ld scripts.
+
+Gentoo previously got away with this because only the toolchain's /lib
+was searched rather than /usr/lib, and the former did not contain many
+*.so files. Now that Gentoo is migrating cross environments to a
+merged-usr layout, these directories are the same, triggering the above
+issues much more frequently.
+
+In particular, the toolchain's /usr/lib/libc.so ld script is found
+before the sysroot's. This includes a reference to /lib/libc.so.6. The
+sysroot is only applied to this when the ld script itself is within that
+sysroot, so /lib/libc.so.6 is taken literally, causing the build
+machine's libc to be used instead, which immediately breaks any linking.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/gcc.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 95b98eaa8..210991153 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5522,6 +5522,7 @@ process_command (unsigned int decoded_options_count,
+   add_prefix (&exec_prefixes,
+ 	      concat (tooldir_prefix, "bin", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 0);
++  if (!target_system_root_changed)
+   add_prefix (&startfile_prefixes,
+ 	      concat (tooldir_prefix, "lib", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 1);
+-- 
+2.47.1
+

--- a/15.0.0/gentoo/13_all_tooldir_prefix_bin.patch
+++ b/15.0.0/gentoo/13_all_tooldir_prefix_bin.patch
@@ -1,0 +1,35 @@
+From cef4c8559cf0a3523d5ff0ae91e56ea6652456c7 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Thu, 2 Jan 2025 12:46:55 +0000
+Subject: [PATCH 2/3] Do not search for tools relative to the driver when
+ cross-compiling
+
+On Gentoo, this location is /usr/${CHOST}/bin. Native toolchains put
+symlinks to the binutils tools here. Cross toolchains only put
+non-native binaries here. The binutils symlinks live under
+/usr/libexec/gcc/${CHOST} instead, and that location is already
+searched.
+
+It would be better to fail to find a given tool than inadvertently try
+to execute a non-native build of it via QEMU.
+
+Signed-off-by: James Le Cuirot <chewi@gentoo.org>
+---
+ gcc/gcc.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 210991153..4188f0049 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -5519,6 +5519,7 @@ process_command (unsigned int decoded_options_count,
+ 	      accel_dir_suffix, dir_separator_str, tooldir_prefix2, NULL);
+   free (tooldir_prefix2);
+ 
++  if (*cross_compile == '0')
+   add_prefix (&exec_prefixes,
+ 	      concat (tooldir_prefix, "bin", dir_separator_str, NULL),
+ 	      "BINUTILS", PREFIX_PRIORITY_LAST, 0, 0);
+-- 
+2.47.1
+

--- a/15.0.0/gentoo/README.history
+++ b/15.0.0/gentoo/README.history
@@ -1,6 +1,8 @@
 36	????
 
 	- 73_all_PR117629-c-special-case-some-bool-errors-with-C23.patch
+	+ 12_all_tooldir_prefix_lib.patch
+	+ 13_all_tooldir_prefix_bin.patch
 
 35	30 December 2024
 


### PR DESCRIPTION
These are small but a tad controversial.

There has long been a desire for crossdev to initialise environments with a given profile rather than the embedded profile that few people actually want. I picked up a PR for this, tried it with a merged-usr profile, and found that things break very badly once you point the sysroot somewhere else.

For some bizarre reason, GCC adds `/usr/${CHOST}/lib` to the library search path _before_ the sysroot's own `/lib` and `/usr/lib`. Gentoo has previously got away with this as there were generally no conflicting libraries in the toolchain's `/lib`, but with merged-usr, this is now the same directory as the toolchain's `/usr/lib`.

Aside from ABI compatibility issues, the toolchain's `/usr/lib/libc.so` ld script is now found before the sysroot's. This includes a reference to `/lib/libc.so.6`. The sysroot is only prepended to this when the ld script itself is within that sysroot, so `/lib/libc.so.6` is taken literally, causing the build machine's libc to be used instead, which immediately breaks any linking.

I couldn't see any good reason to use the toolchain's `/lib` when the sysroot has been changed, so the "lib" patch simply omits it in that case.

The "bin" patch involves the code immediately before. The issue here is similar in that `/usr/${CHOST}/bin` is searched for toolchain programs, but at least on Gentoo, only non-native binaries live here. It would be better to fail to find a given tool than inadvertently try to execute a non-native build of it via QEMU. While this change is not strictly necessary, I felt it made sense alongside the first change.

Note that I have deliberately not adjusted the whitespace of the existing code to keep the patches minimal. This way, they only add a single line each.

I didn't want to submit the "lib" patch without considering whether Clang would need similar treatment. It sadly does suffer from the same issue. You can kind of work around it by pointing `--gcc-install-dir` inside the sysroot, but this gets messy when bootstrapping a new system. When I found the code responsible though, it turned out to reveal much more about GCC than it did about Clang.

```c++
    // GCC cross compiling toolchains will install target libraries which ship
    // as part of the toolchain under <prefix>/<triple>/<libdir> rather than as
    // any part of the GCC installation in
    // <prefix>/<libdir>/gcc/<triple>/<version>. This decision is somewhat
    // debatable, but is the reality today. We need to search this tree even
    // when we have a sysroot somewhere else. It is the responsibility of
    // whomever is doing the cross build targeting a sysroot using a GCC
    // installation that is *not* within the system root to ensure two things:
    //
    //  1) Any DSOs that are linked in from this tree or from the install path
    //     above must be present on the system root and found via an
    //     appropriate rpath.
    //  2) There must not be libraries installed into
    //     <prefix>/<triple>/<libdir> unless they should be preferred over
    //     those within the system root.
    //
    // Note that this matches the GCC behavior. See the below comment for where
    // Clang diverges from GCC's behavior.
    addPathIfExists(D,
                    LibPath + "/../" + GCCTriple.str() + "/lib/../" + OSLibDir +
                        SelectedMultilibs.back().osSuffix(),
                    Paths);
```

With merged-usr, we are totally violating that second rule. The original commit from 2013 (llvm/llvm-project@7f8042c8f3b1cfda2c4576888b54e06a701512e6) says a little more about how this behaviour is "frustrating" but apparently necessary for Android and MIPS platforms. I take that to mean their SDKs.

I can confirm that gating the above line with `if (SysRoot.empty())` fixes the issue, although another line just below is needed to avoid the corresponding `/lib` (as opposed to `/lib64`) entry.

Since upstream clearly thought this behaviour is terrible, I don't feel so bad about nullifying it. I don't think we need to worry about what is needed by these SDKs (if they even do still need this) because they probably have their own toolchains. I can't really see any other way around it. merged-usr is now the default, so cross environments really should support it.

As for the "bin" patch, Clang also mirrors GCC's behaviour here, but I think it is less likely to fall back to the problematic directory, as everything it needs should be in `/usr/lib/llvm/${V}/bin`, which is where it looks first.